### PR TITLE
Add support for sass indented syntax

### DIFF
--- a/src/sass-builder.js
+++ b/src/sass-builder.js
@@ -53,12 +53,12 @@ export default (loads, compileOpts) => {
     return `${(compileOpts.systemGlobal || 'System')}\.register('${load.name}', [], false, function() {});`;
   }).join('\n');
 
-  const compile_promise = load => {
+  const compilePromise = load => {
     return new Promise((resolve, reject) => {
       urlBase = load.address;
       const options = {
         style: sass.style.compressed,
-        indentedSyntax: urlBase.split('.').slice(-1)[0] == 'sass'
+        indentedSyntax: urlBase.endsWith('.sass'),
       };
       sass.compile(load.source, options, result => {
         if (result.status === 0) {
@@ -71,7 +71,7 @@ export default (loads, compileOpts) => {
   };
   return new Promise((resolve, reject) => {
     // Keep style order
-    Promise.all(loads.map(compile_promise))
+    Promise.all(loads.map(compilePromise))
     .then(
       response => resolve([stubDefines, cssInject, `("${escape(response.reverse().join(''))}");`].join('\n')),
       reason => reject(reason));

--- a/src/sass-builder.js
+++ b/src/sass-builder.js
@@ -34,8 +34,8 @@ const loadFile = path => {
 
 // intercept file loading requests (@import directive) from libsass
 sass.importer((request, done) => {
-// Currently only supporting scss imports due to
-// https://github.com/sass/libsass/issues/1695
+  // Currently only supporting scss imports due to
+  // https://github.com/sass/libsass/issues/1695
   const importUrl = url.resolve(urlBase, `${request.current}.scss`);
   const partialUrl = importUrl.replace(/\/([^/]*)$/, '/_$1');
   const readImportPath = querystring.unescape(url.parse(importUrl).path);

--- a/src/sass-builder.js
+++ b/src/sass-builder.js
@@ -15,6 +15,7 @@ const escape = source => {
     .replace(/[\n]/g, '\\n')
     .replace(/[\t]/g, '\\t')
     .replace(/[\r]/g, '\\r')
+    .replace(/[\ufeff]/g, '')
     .replace(/[\u2028]/g, '\\u2028')
     .replace(/[\u2029]/g, '\\u2029');
 };

--- a/src/sass-inject.js
+++ b/src/sass-inject.js
@@ -62,13 +62,15 @@ const compile = scss => {
 
 export default load => {
   urlBase = load.address;
-  let indentedSyntax = urlBase.split('.').slice(-1)[0] == 'sass'
+  const indentedSyntax = urlBase.endsWith('.sass');
   // load initial scss file
   return reqwest(urlBase)
     // In Cordova Apps the response is the raw XMLHttpRequest
-    .then(resp => { return {
-      content: (resp.responseText ? resp.responseText : resp),
-      options: { indentedSyntax }
-    }})
+    .then(resp => {
+      return {
+        content: (resp.responseText ? resp.responseText : resp),
+        options: { indentedSyntax },
+      };
+    })
     .then(compile);
 };

--- a/test/bundle-static-test.jade
+++ b/test/bundle-static-test.jade
@@ -6,5 +6,5 @@ html
     meta(http-equiv='Content-Type', content='text/html; charset=UTF-8')
     script(src='bundle.js')
   body
-    h1 I should become blue and background should show a SASS logo
-    p I SHOULD BE ALL LOWERCASE
+    h1 I should become blue and background should show a SASS logo on a white background
+    p I SHOULD BE ALL LOWERCASE UNDERLINED AND CENTERED

--- a/test/bundle-test.jade
+++ b/test/bundle-test.jade
@@ -15,6 +15,6 @@ html
             });
         });
   body
-    h1 I should become blue and background should show a SASS logo
+    h1 I should become blue and background should show a SASS logo on a white background
     h2 Loading...
-    p I SHOULD BE ALL LOWERCASE
+    p I SHOULD BE ALL LOWERCASE UNDERLINED AND CENTERED

--- a/test/bundleme.js
+++ b/test/bundleme.js
@@ -1,3 +1,5 @@
 import 'test/styles/test.scss!';
+import 'test/styles/test_sass.sass!scss';
+import 'test/styles/test_other.scss!';
 
 console.log('I am bundled');

--- a/test/runtime-test.jade
+++ b/test/runtime-test.jade
@@ -8,10 +8,12 @@ html
     script(src='config.js')
     script(type='text/javascript').
       System.import('styles/test.scss!')
+        .then(() => System.import('styles/test_sass.sass!scss'))
+        .then(() => System.import('styles/test_other.scss!'))
         .then(() => {
           document.body.innerHTML += '<h2>Loading done</h2>';
         });
   body
-    h1 I should become blue and background should show a SASS logo
+    h1 I should become blue and background should show a SASS logo on a white background
     h2 Loading...
-    p I SHOULD BE ALL LOWERCASE
+    p I SHOULD BE ALL LOWERCASE UNDERLINED AND CENTERED

--- a/test/styles/test.scss
+++ b/test/styles/test.scss
@@ -6,4 +6,5 @@ $image: '../images/sass-logo.svg';
 body {
   background-image: url($image);
   background-repeat: no-repeat;
+  background-color: pink;
 }

--- a/test/styles/test_other.scss
+++ b/test/styles/test_other.scss
@@ -1,0 +1,6 @@
+body {
+  background-color: transparent;
+  p {
+    text-decoration: underline;
+  }
+}

--- a/test/styles/test_sass.sass
+++ b/test/styles/test_sass.sass
@@ -1,0 +1,4 @@
+body
+  background-color: blue
+  p
+    text-align: center


### PR DESCRIPTION
Add support for indented syntax (import 'style.sass!scss')
Internal sass imports are not yet supported as per https://github.com/sass/libsass/issues/1695

Please review.