### PR TITLE
Replace .endsWith call with lodash variant for compatibility

### DIFF
--- a/src/sass-inject.js
+++ b/src/sass-inject.js
@@ -3,6 +3,7 @@
 import './modernizr';
 
 import autoprefixer from 'autoprefixer';
+import endsWith from 'lodash/string/endsWith';
 import isEmpty from 'lodash/lang/isEmpty';
 import isString from 'lodash/lang/isString';
 import isUndefined from 'lodash/lang/isUndefined';
@@ -85,7 +86,7 @@ const compile = scss => {
 
 export default load => {
   const urlBase = path.dirname(url.parse(load.address).pathname) + '/';
-  const indentedSyntax = load.address.endsWith('.sass');
+  const indentedSyntax = endsWith(load.address, '.sass');
   // load initial scss file
   return reqwest(load.address)
     // In Cordova Apps the response is the raw XMLHttpRequest


### PR DESCRIPTION
[String.prototype.endsWith is an ES6 method](http://kangax.github.io/compat-table/es6/#test-String.prototype_methods_String.prototype.endsWith) which isn't implemented everywhere yet - specifically there is not a single IE which has it implemented which makes developing for IE hard when not using a polyfill.

This PR replaces the method calls with lodash function calls. 