### PR TITLE
Fix incorrect urlBase when the load address is the resource root.

### DIFF
--- a/src/sass-inject.js
+++ b/src/sass-inject.js
@@ -84,7 +84,12 @@ const compile = scss => {
 };
 
 export default load => {
-  const urlBase = path.dirname(url.parse(load.address).pathname) + '/';
+  let basePath = path.dirname(url.parse(load.address).pathname);
+  if (basePath !== '/') {
+    basePath += '/';
+  }
+
+  const urlBase = basePath;
   const indentedSyntax = load.address.endsWith('.sass');
   // load initial scss file
   return reqwest(load.address)

--- a/test/resolve-path.spec.js
+++ b/test/resolve-path.spec.js
@@ -8,6 +8,23 @@ test('sanity check', assert => {
   assert.end();
 });
 
+test('import', assert => {
+  let request = {
+    current: 'mock/import',
+    previous: 'stdin',
+    options: {
+      urlBase: '/'
+    }
+  };
+
+  resolvePath(request, '/')
+    .then(p => {
+      assert.equal(p, '/mock/import.scss', 'resolves import.');
+    })
+    .catch(e => assert.fail(e))
+    .then(() => assert.end());
+});
+
 test('jspm import', assert => {
   System.config({
     baseURL: __dirname,

--- a/test/resolve-path.spec.js
+++ b/test/resolve-path.spec.js
@@ -9,12 +9,12 @@ test('sanity check', assert => {
 });
 
 test('import', assert => {
-  let request = {
+  const request = {
     current: 'mock/import',
     previous: 'stdin',
     options: {
-      urlBase: '/'
-    }
+      urlBase: '/',
+    },
   };
 
   resolvePath(request, '/')


### PR DESCRIPTION
Addresses #32. If the SystemJS `baseURL` is to the root and the SystemJS import is not in a folder eg.

```
System.config({
 baseURL: '/'
});

...

System.import('sample.scss!')
```

Then the `urlBase` should set to `/`. However, currently a trailing slash is always added to the `urlBase`, which breaks the importer when the `urlBase` is already `/`. To see the effects of this, modify the new test added to set `urlBase` to `//`. The test will fail.

I've gone back and updated #32 to reflect the conclusion I've come to regarding the problem.