### PR TITLE
Fix test that fails on Windows due to path separator differences.

### DIFF
--- a/test/resolve-path.spec.js
+++ b/test/resolve-path.spec.js
@@ -29,8 +29,8 @@ test('jspm import', assert => {
   resolvePath(request, '/')
     .then(p => {
       // System.normalize in resolvePath will give us the absolute path
-      const relative = '/' + path.relative(__dirname, url.parse(p).path);
-      assert.equal(relative, '/jspm_packages/npm/mock-package@1.0.0/mock-asset.scss', 'resolves "jspm:" import');
+      const relative = `/${path.relative(__dirname, url.parse(p).path)}`;
+      assert.equal(relative, `/${path.join('jspm_packages', 'npm', 'mock-package@1.0.0', 'mock-asset.scss')}`);
     })
     .catch(e => assert.fail(e))
     .then(() => assert.end());


### PR DESCRIPTION
Not a big deal but it causes `npm install` to error out on Windows during `prepublish` (which runs `gulp`, which runs the tests). Just momentarily jarring as initially you don't know if anything critical went wrong during the install process.