### PR TITLE
Remove old scripts after reloads

### DIFF
--- a/src/sass-inject.js
+++ b/src/sass-inject.js
@@ -52,7 +52,7 @@ importSass.then(sass => {
   sass.importer(sassImporter);
 });
 
-async function compile(scss) {
+async function compile(scss, url) {
   const content = scss.content;
   const responseText = content.responseText;
   if (isString(content) && isEmpty(content) ||
@@ -60,9 +60,19 @@ async function compile(scss) {
     return '';
   }
   const sass = await importSass;
+
+  function tryCleanup(url) {
+    const element = document.querySelector(`style[data-url="${url}"]`);
+    if (element) {
+      element.parentElement.removeChild(element);
+    }
+  }
+
   function inject(css) {
+    tryCleanup(url);
     const style = document.createElement('style');
     style.setAttribute('type', 'text/css');
+    style.setAttribute('data-url', url);
     style.textContent = css;
     document.getElementsByTagName('head')[0].appendChild(style);
   }
@@ -104,5 +114,5 @@ export default async function sassInject(load) {
     content: resp.responseText ? resp.responseText : resp,
     options,
   };
-  return compile(scss);
+  return compile(scss, load.address);
 }

--- a/src/sass-inject.js
+++ b/src/sass-inject.js
@@ -52,7 +52,7 @@ importSass.then(sass => {
   sass.importer(sassImporter);
 });
 
-async function compile(scss, url) {
+async function compile(scss, styleUrl) {
   const content = scss.content;
   const responseText = content.responseText;
   if (isString(content) && isEmpty(content) ||
@@ -61,18 +61,18 @@ async function compile(scss, url) {
   }
   const sass = await importSass;
 
-  function tryCleanup(url) {
-    const element = document.querySelector(`style[data-url="${url}"]`);
+  function tryCleanup() {
+    const element = document.querySelector(`style[data-url="${styleUrl}"]`);
     if (element) {
       element.parentElement.removeChild(element);
     }
   }
 
   function inject(css) {
-    tryCleanup(url);
+    tryCleanup();
     const style = document.createElement('style');
     style.setAttribute('type', 'text/css');
-    style.setAttribute('data-url', url);
+    style.setAttribute('data-url', styleUrl);
     style.textContent = css;
     document.getElementsByTagName('head')[0].appendChild(style);
   }


### PR DESCRIPTION
By adding a `data-url` attribute to the style tags in development we accomplish two things:

- It's easier to find the source of the style when debugging.
- We can easily remove the old script tag when live reloading. Maybe it should be done on unload instead, but I think this will avoid any flickering when replacing the stylesheet.

I do think we need something like this, but maybe somebody has a better solution?