### PR TITLE
fix for import of scss files from jspm packages

### DIFF
--- a/src/resolve-path.js
+++ b/src/resolve-path.js
@@ -9,7 +9,13 @@ async function resolvePath(request) {
   if (current.substr(0, 5) === 'jspm:') {
     current = current.replace(/^jspm:/, '');
     if (!current.match(/\.s(c|a)ss/)) current += '.scss';
-    const file = await System.normalize(current);
+    // we need the parent, if the module of the file is not a primary install
+    let parent = `${System.baseURL}${request.options.urlBase}`;
+    // when adding urls, some unwanted double slashes may occur
+    if (System.baseURL.slice(-1) === '/' && request.options.urlBase.slice(0, 1) === '/') {
+      parent = `${System.baseURL}${request.options.urlBase.slice(1)}`;
+    }
+    const file = await System.normalize(current, parent);
     return file.replace(/\.js$|\.ts$/, '');
   }
   const prevBase = `${path.dirname(previous)}/`;


### PR DESCRIPTION
Jspm package path can not be found if i try to `@import 'jspm:package-a/some-scss-file';` in a package-b, which is installed in a third package-c.

`System.normalize` needs to know the parent package if it is not primaliry installed.

Here comes the fix. (Yes, including a test.)