### PR TITLE
fixed creation of parent url when importing sass files from other packages in sass files

### DIFF
--- a/src/resolve-path.js
+++ b/src/resolve-path.js
@@ -11,7 +11,7 @@ async function resolvePath(request) {
     if (!current.match(/\.s(c|a)ss/)) current += '.scss';
     // we need the parent, if the module of the file is not a primary install
     const parentURL = url.parse(System.baseURL);
-    parentURL.pathname = request.options.urlBase;
+    parentURL.pathname = url.parse(request.options.urlBase).pathname;
     const parent = url.format(parentURL);
     const file = await System.normalize(current, parent);
     return file.replace(/\.js$|\.ts$/, '');


### PR DESCRIPTION
now it works not only in browsers and mobile browsers, but also on `jspm bundle`