### PR TITLE
fixed function signature that failed while using TypeScript compiler

### DIFF
--- a/src/sass-inject.js
+++ b/src/sass-inject.js
@@ -13,7 +13,7 @@ import url from 'url';
 
 import resolvePath from './resolve-path';
 
-const importSass = new Promise(async resolve => {
+const importSass = new Promise(async (resolve, reject) => {
   if (Modernizr.webworkers) {
     const Sass = await System.import('sass.js/dist/sass', __moduleName);
     const worker = await System.normalize('sass.js/dist/sass.worker', __moduleName);

--- a/src/sass-inject.js
+++ b/src/sass-inject.js
@@ -13,7 +13,7 @@ import url from 'url';
 
 import resolvePath from './resolve-path';
 
-const importSass = new Promise(async (resolve, reject) => {
+const importSass = new Promise(async (resolve) => {
   if (Modernizr.webworkers) {
     const Sass = await System.import('sass.js/dist/sass', __moduleName);
     const worker = await System.normalize('sass.js/dist/sass.worker', __moduleName);


### PR DESCRIPTION
TypeScript doesn't understand this abbreviated syntax. It's been failing to compile, so I came up with a fix.