### PR TITLE
loads optional deps only if required

### DIFF
--- a/src/sass-builder.js
+++ b/src/sass-builder.js
@@ -4,7 +4,6 @@ import isEmpty from 'lodash/isEmpty';
 import path from 'path';
 import sass from 'sass.js';
 
-import CssUrlRewriter from 'css-url-rewriter-ex';
 import CssAssetCopier from 'css-asset-copier';
 
 import resolvePath from './resolve-path';
@@ -105,6 +104,8 @@ export default async function sassBuilder(loads, compileOpts, outputOpts) {
 
     // rewrite urls and copy assets if enabled
     if (pluginOptions.rewriteUrl) {
+      const CssUrlRewriterModule = await System.import('css-url-rewriter-ex', __moduleName);
+      const CssUrlRewriter = CssUrlRewriterModule.default;
       const urlRewriter = new CssUrlRewriter({ root: System.baseURL });
       text = urlRewriter.rewrite(load.address, text);
       if (pluginOptions.copyAssets) {

--- a/src/sass-builder.js
+++ b/src/sass-builder.js
@@ -1,9 +1,7 @@
-import autoprefixer from 'autoprefixer';
 import cloneDeep from 'lodash/cloneDeep';
 import fs from 'fs';
 import isEmpty from 'lodash/isEmpty';
 import path from 'path';
-import postcss from 'postcss';
 import sass from 'sass.js';
 
 import CssUrlRewriter from 'css-url-rewriter-ex';
@@ -121,6 +119,8 @@ export default async function sassBuilder(loads, compileOpts, outputOpts) {
       const autoprefixerOptions = pluginOptions.autoprefixer instanceof Object
         ? pluginOptions.autoprefixer
         : undefined;
+      const postcss = await System.import('postcss', __moduleName);
+      const autoprefixer = await System.import('autoprefixer', __moduleName);
       const { css } = await postcss([autoprefixer(autoprefixerOptions)]).process(text);
       text = css;
     }

--- a/src/sass-inject.js
+++ b/src/sass-inject.js
@@ -1,10 +1,8 @@
-import autoprefixer from 'autoprefixer';
 import cloneDeep from 'lodash/cloneDeep';
 import isEmpty from 'lodash/isEmpty';
 import isString from 'lodash/isString';
 import isUndefined from 'lodash/isUndefined';
 import path from 'path';
-import postcss from 'postcss';
 import reqwest from 'reqwest';
 import url from 'url';
 
@@ -104,6 +102,8 @@ async function compile(scss, styleUrl) {
     const autoprefixerOptions = pluginOptions.autoprefixer instanceof Object
       ? pluginOptions.autoprefixer
       : undefined;
+    const postcss = await System.import('postcss', __moduleName);
+    const autoprefixer = await System.import('autoprefixer', __moduleName);
     const { css } = await postcss([autoprefixer(autoprefixerOptions)]).process(text);
     text = css;
   }

--- a/src/sass-inject.js
+++ b/src/sass-inject.js
@@ -6,8 +6,6 @@ import path from 'path';
 import reqwest from 'reqwest';
 import url from 'url';
 
-import CssUrlRewriter from 'css-url-rewriter-ex';
-
 import resolvePath from './resolve-path';
 
 function injectStyle(css, address) {
@@ -93,6 +91,8 @@ async function compile(scss, styleUrl) {
   // rewrite urls and copy assets if enabled
   const pluginOptions = System.sassPluginOptions || {};
   if (pluginOptions.rewriteUrl) {
+    const CssUrlRewriterModule = await System.import('css-url-rewriter-ex', __moduleName);
+    const CssUrlRewriter = CssUrlRewriterModule.default;
     const urlRewriter = new CssUrlRewriter({ root: System.baseURL });
     text = urlRewriter.rewrite(styleUrl, text);
   }


### PR DESCRIPTION
This loads postcss and autoprefixer and CssUrlRewriter using `System.import` on runtime to speed up loading of sass/scss if autoprefixer/rewriteUrl is disabled.

Thanks for the great plugin. Let me know if I missed something.